### PR TITLE
Make the output use SOURCE_DATE_EPOCH[0] and non-timezone timestamps

### DIFF
--- a/txt2tags
+++ b/txt2tags
@@ -7830,7 +7830,7 @@ class MacroMaster:
         self.infile   = self.config['sourcefile']
         self.outfile  = self.config['outfile']
         self.currentfile = self.config['currentsourcefile']
-        self.currdate = time.localtime(time.time())
+        self.currdate = self.currdate = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
         self.rgx      = regex.get('macros') or getRegexes()['macros']
         self.fileinfo = {'infile': None, 'outfile': None}
         self.dft_fmt  = MACROS
@@ -7926,7 +7926,7 @@ class MacroMaster:
                         fdate = self.currdate
                 else:
                     mtime = os.path.getmtime(self.infile)
-                    fdate = time.localtime(mtime)
+                    fdate = time.gmtime(mtime)
                 txt = time.strftime(fmt, fdate)
             elif name in ('infile', 'outfile', 'currentfile'):
                 self.set_file_info(name)


### PR DESCRIPTION
Whilst working on the "reproducible builds" effort [1], we noticed
that txt2tags generates non-reproducible output.

Patch attached.

 [0] https://reproducible-builds.org/specs/source-date-epoch/
 [1] https://wiki.debian.org/ReproducibleBuilds