### PR TITLE
File read/write: Force UTF-8, improved error handling

### DIFF
--- a/test/includeconf/ok/C-not-found.out
+++ b/test/includeconf/ok/C-not-found.out
@@ -1,1 +1,1 @@
-txt2tags: Error: Cannot read file: XXX.inc
+txt2tags: Error: File not found: XXX.inc

--- a/test/includeconf/ok/config-file-not-found.out
+++ b/test/includeconf/ok/config-file-not-found.out
@@ -1,1 +1,1 @@
-txt2tags: Error: Cannot read file: XXX.inc
+txt2tags: Error: File not found: XXX.inc

--- a/test/includeconf/ok/includeconf-not-found.out
+++ b/test/includeconf/ok/includeconf-not-found.out
@@ -1,1 +1,1 @@
-txt2tags: Error: Cannot read file: XXX.inc
+txt2tags: Error: File not found: XXX.inc

--- a/test/options/ok/infile-not-found-1.out
+++ b/test/options/ok/infile-not-found-1.out
@@ -1,1 +1,1 @@
-txt2tags: Error: Cannot read file: ERROR.t2t
+txt2tags: Error: File not found: ERROR.t2t

--- a/test/options/ok/infile-not-found-2.out
+++ b/test/options/ok/infile-not-found-2.out
@@ -1,1 +1,1 @@
-txt2tags: Error: Cannot read file: ERROR.t2t
+txt2tags: Error: File not found: ERROR.t2t

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1803,22 +1803,20 @@ def Debug(msg, id_=0, linenr=None):
     print("++ {}: {}".format(ids[id_], msg))
 
 
-def Readfile(file_path, remove_linebreaks=False, ignore_error=False):
+def Readfile(file_path, remove_linebreaks=False):
     data = []
     if file_path == "-":
         try:
             data = sys.stdin.readlines()
         except Exception:
-            if not ignore_error:
-                Error("You must feed me with data on STDIN!")
+            Error("You must feed me with data on STDIN!")
     else:
         try:
             f = open(file_path)
             data = f.readlines()
             f.close()
         except Exception:
-            if not ignore_error:
-                Error("Cannot read file:" + " " + file_path)
+            Error("Cannot read file:" + " " + file_path)
     if remove_linebreaks:
         data = [re.sub("[\n\r]+$", "", x) for x in data]
     Message("File read (%d lines): %s" % (len(data), file_path), 2)

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1812,7 +1812,7 @@ def Readfile(file_path, remove_linebreaks=False):
             Error("You must feed me with data on STDIN!")
     else:
         try:
-            f = open(file_path)
+            f = open(file_path, encoding="utf-8")
             data = f.readlines()
             f.close()
         except FileNotFoundError:
@@ -1825,7 +1825,7 @@ def Readfile(file_path, remove_linebreaks=False):
 
 def Savefile(file_path, lines):
     try:
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             for line in lines:
                 f.write(line + "\n")
     except IOError as exception:

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1815,8 +1815,8 @@ def Readfile(file_path, remove_linebreaks=False):
             f = open(file_path)
             data = f.readlines()
             f.close()
-        except Exception:
-            Error("Cannot read file:" + " " + file_path)
+        except FileNotFoundError:
+            Error("File not found: " + file_path)
     if remove_linebreaks:
         data = [re.sub("[\n\r]+$", "", x) for x in data]
     Message("File read (%d lines): %s" % (len(data), file_path), 2)

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1828,8 +1828,8 @@ def Savefile(file_path, lines):
         with open(file_path, "w") as f:
             for line in lines:
                 f.write(line + "\n")
-    except IOError:
-        Error("Cannot open file for writing:" + " " + file_path)
+    except IOError as exception:
+        Error("Cannot open file for writing: {}\n{}".format(file_path, exception))
 
 
 def dotted_spaces(txt=""):


### PR DESCRIPTION
While investigating issue #212, I've found out that the original error message was being hidden due a too broad exception catch clause. After commenting it, the errors were shown and it was easier to search for the fix.

Since I was reading `Readfile()` and `Savefile()`, I've also made some simple improvements. Each should be in a separate PR ideally, but since they change the same function, I'm submitting it as a single PR to avoid conflicts. Please tell me if it's better to do it otherwise.

This PR:

- Fixes the broad catch
- Removes the unused `ignore_error` parameter
- Shows the error cause when failing to write the file
- Force UTF-8 when reading/writing files, hopefully fixing #212 
