### PR TITLE
Savefile: in case of failure, show the original error message

### DIFF
--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1830,8 +1830,8 @@ def Savefile(file_path, lines):
         with open(file_path, "w") as f:
             for line in lines:
                 f.write(line + "\n")
-    except IOError:
-        Error("Cannot open file for writing:" + " " + file_path)
+    except IOError as exception:
+        Error("Cannot open file for writing: {}\n{}".format(file_path, exception))
 
 
 def dotted_spaces(txt=""):


### PR DESCRIPTION
So the user can have a clue on what the problem is. Example:

```console
$ mkdir a.html
$ printf '\nfoo' > a.t2t
$ python3 ./txt2tags.py -t html a.t2t
txt2tags: Error: Cannot open file for writing: a.html
[Errno 21] Is a directory: 'a.html'
$
```