### PR TITLE
Readfile: in case of failure, show the original error message

### DIFF
--- a/test/includeconf/ok/C-not-found.out
+++ b/test/includeconf/ok/C-not-found.out
@@ -1,1 +1,2 @@
 txt2tags: Error: Cannot read file: XXX.inc
+[Errno 2] No such file or directory: 'XXX.inc'

--- a/test/includeconf/ok/config-file-not-found.out
+++ b/test/includeconf/ok/config-file-not-found.out
@@ -1,1 +1,2 @@
 txt2tags: Error: Cannot read file: XXX.inc
+[Errno 2] No such file or directory: 'XXX.inc'

--- a/test/includeconf/ok/includeconf-not-found.out
+++ b/test/includeconf/ok/includeconf-not-found.out
@@ -1,1 +1,2 @@
 txt2tags: Error: Cannot read file: XXX.inc
+[Errno 2] No such file or directory: 'XXX.inc'

--- a/test/options/ok/infile-not-found-1.out
+++ b/test/options/ok/infile-not-found-1.out
@@ -1,1 +1,2 @@
 txt2tags: Error: Cannot read file: ERROR.t2t
+[Errno 2] No such file or directory: 'ERROR.t2t'

--- a/test/options/ok/infile-not-found-2.out
+++ b/test/options/ok/infile-not-found-2.out
@@ -1,1 +1,2 @@
 txt2tags: Error: Cannot read file: ERROR.t2t
+[Errno 2] No such file or directory: 'ERROR.t2t'

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1815,8 +1815,8 @@ def Readfile(file_path, remove_linebreaks=False):
             f = open(file_path)
             data = f.readlines()
             f.close()
-        except Exception:
-            Error("Cannot read file:" + " " + file_path)
+        except Exception as exception:
+            Error("Cannot read file: {}\n{}".format(file_path, exception))
     if remove_linebreaks:
         data = [re.sub("[\n\r]+$", "", x) for x in data]
     Message("File read (%d lines): %s" % (len(data), file_path), 2)


### PR DESCRIPTION
Previously, only the generic "Cannot read file" was shown to the user.
Now the reason why the file cannot be read is shown in the second line
of the output.

Examples:

    $ ./txt2tags.py -t html -i not-found.t2t
    txt2tags: Error: Cannot read file: not-found.t2t
    [Errno 2] No such file or directory: 'not-found.t2t'

    $ ./txt2tags.py -t html -i samples
    txt2tags: Error: Cannot read file: samples
    [Errno 21] Is a directory: 'samples'

    $ chmod 000 README.md
    $ ./txt2tags.py -t html -i README.md
    txt2tags: Error: Cannot read file: README.md
    [Errno 13] Permission denied: 'README.md'