### PR TITLE
Readfile: Fix exception type for STDIN reading

### DIFF
--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1808,7 +1808,7 @@ def Readfile(file_path, remove_linebreaks=False):
     if file_path == "-":
         try:
             data = sys.stdin.readlines()
-        except Exception:
+        except KeyboardInterrupt:
             Error("You must feed me with data on STDIN!")
     else:
         try:


### PR DESCRIPTION
This specific line was introduced in txt2tags version 1.0, from 2002. By
that time, every exception used to have `Exception` as the root class,
so this used to work for the use-case of hitting Control-C when txt2tags
seemed frozen (but in fact was just waiting for data in STDIN).

In recent Python 2.7 and 3.x, `KeyboardInterrupt` is derived from
`BaseException` instead, so this is not catching Control-C anymore.

The fix is simple: use the specific `KeyboardInterrupt` exception
instead of a generic one (sorry, in 2002 I did not know better).