### PR TITLE
Readfile: Avoid too broad exception catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Version 3.5 (unreleased)
 
 * Drop `--encoding` option and always use UTF-8 (Jendrik Seipp).
-* Remove unused ignore_error parameter from Readfile function (Aurelio Jargas, #215).
-* When writing the output file fails, show the original error message (Aurelio Jargas, #216).
-* If reading the input file fails, show the original error message (Aurelio Jargas, #217).
-* Fix exception type for STDIN reading (Aurelio Jargas, #218).
+* Show the original error message when a file read/write operation fails (Aurelio Jargas, #216 #217).
+* Improve the exception handling when reading input data from files and from STDIN (Aurelio Jargas, #218 #219).
 
 # Version 3.4 (2019-12-25)
 

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1814,7 +1814,7 @@ def Readfile(file_path):
         try:
             with open(file_path) as f:
                 data = f.readlines()
-        except Exception as exception:
+        except IOError as exception:
             Error("Cannot read file: {}\n{}".format(file_path, exception))
     data = [re.sub("[\n\r]+$", "", x) for x in data]
     Message("File read (%d lines): %s" % (len(data), file_path), 2)


### PR DESCRIPTION
As currently done in Savefile(), only IO errors are the "safe" errors to
catch when trying to read a file. All other kinds of errors should raise
a failure and show the normal traceback, because they are unexpected.