### PR TITLE
Readfile: Use splitlines() instead of regex

### DIFF
--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1804,21 +1804,20 @@ def Debug(msg, id_=0, linenr=None):
 
 
 def Readfile(file_path):
-    data = []
     if file_path == "-":
         try:
-            data = sys.stdin.readlines()
+            contents = sys.stdin.read()
         except KeyboardInterrupt:
             Error("You must feed me with data on STDIN!")
     else:
         try:
             with open(file_path) as f:
-                data = f.readlines()
+                contents = f.read()
         except IOError as exception:
             Error("Cannot read file: {}\n{}".format(file_path, exception))
-    data = [re.sub("[\n\r]+$", "", x) for x in data]
-    Message("File read (%d lines): %s" % (len(data), file_path), 2)
-    return data
+    lines = contents.splitlines()
+    Message("File read (%d lines): %s" % (len(lines), file_path), 2)
+    return lines
 
 
 def Savefile(file_path, lines):


### PR DESCRIPTION
Python already have that functionality of getting a list of all lines
from a text, with no line breaks. We don't need to reimplement that with
regexes :)

Also renamed some variables to make the intent clearer and to be more
consistent (`Savefile()` already uses `lines`).