### PR TITLE
Force UTF-8 enconding when reading/writing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 3.5 (unreleased)
 
 * Add Markdown target (Eric Forgeot, #213).
-* Drop `--encoding` option and always use UTF-8 (Jendrik Seipp).
+* Drop `--encoding` option and always use UTF-8. Files in other encodings are not supported anymore (Jendrik Seipp, Aurelio Jargas, e4e56d9 #221).
 * Show the original error message when a file read/write operation fails (Aurelio Jargas, #216 #217).
 * Improve the exception handling when reading input data from files and from STDIN (Aurelio Jargas, #218 #219).
 

--- a/test/includeconf/ok/includeconf-not-found.out
+++ b/test/includeconf/ok/includeconf-not-found.out
@@ -1,2 +1,1 @@
 txt2tags: Error: Cannot read file: XXX.inc
-[Errno 2] No such file or directory: 'XXX.inc'

--- a/test/includeconf/run.py
+++ b/test/includeconf/run.py
@@ -70,7 +70,11 @@ def run():
             cmdline = ["-H", "-i", infile, "-o", outfile]
 
         if lib.initTest(basename, infile, outfile, okfile):
-            lib.test(cmdline, outfile, okfile)
+            if basename in errors:
+                lib._convert(cmdline)
+                lib._grep(okfile, outfile)
+            else:
+                lib.test(cmdline, outfile, okfile)
 
     # Now test -C and --config-file command line options.
     errors = ["C-not-found", "C-text"]

--- a/test/lib.py
+++ b/test/lib.py
@@ -134,6 +134,20 @@ def override(okfile, outfile):
         MoveFile(outfile, okfile)
 
 
+def _grep(okfile, outfile):
+    """grep if the okfile snippet is contained in outfile"""
+    ok = ReadFile(okfile)
+    out = ReadFile(outfile)
+    if ok not in out:
+        if OVERRIDE:
+            override(okfile, outfile)
+        else:
+            mark_failed(outfile, okfile=okfile)
+            print("_grep: {okfile} contents not found in {outfile}".format(**locals()))
+    else:
+        mark_ok(outfile)
+
+
 def _diff(outfile, okfile):
     out = ReadFile(outfile)
     out = remove_version_and_dates(out)

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -76,8 +76,6 @@ import os
 import re
 import sys
 
-is_python2 = sys.version_info[0] == 2
-
 ##############################################################################
 
 # Program information
@@ -160,6 +158,7 @@ DEBUG = 0  # do not edit here, please use --debug
 VERBOSE = 0  # do not edit here, please use -v, -vv or -vvv
 QUIET = 0  # do not edit here, please use --quiet
 
+ENCODING = "utf-8"
 DFT_TEXT_WIDTH = 72
 
 RC_RAW = []
@@ -1890,7 +1889,7 @@ def Readfile(file_path):
             Error("You must feed me with data on STDIN!")
     else:
         try:
-            with io.open(file_path, encoding="utf-8") as f:
+            with io.open(file_path, encoding=ENCODING) as f:
                 contents = f.read()
         except IOError as exception:
             Error("Cannot read file: {}\n{}".format(file_path, exception))
@@ -1900,13 +1899,13 @@ def Readfile(file_path):
 
 
 def Savefile(file_path, lines):
+    contents = "\n".join(lines) + "\n"
     try:
-        with io.open(file_path, "w", encoding="utf-8") as f:
-            for line in lines:
-                if is_python2:
-                    f.write((line + "\n").decode("utf-8"))
-                else:
-                    f.write(line + "\n")
+        with io.open(file_path, "w", encoding=ENCODING) as f:
+            try:
+                f.write(contents)
+            except TypeError:
+                f.write(contents.decode(ENCODING))
     except IOError as exception:
         Error("Cannot open file for writing: {}\n{}".format(file_path, exception))
 
@@ -2997,7 +2996,7 @@ class TitleMaster:
             ret.append(tagged)
             # Get the right letter count for UTF
             if isinstance(full_title, bytes):
-                full_title = full_title.decode("utf-8")
+                full_title = full_title.decode(ENCODING)
             ret.append(regex["x"].sub("=" * len(full_title), self.tag))
         else:
             ret.append(tagged)

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -71,9 +71,12 @@ from __future__ import print_function
 
 import collections
 import getopt
+import io
 import os
 import re
 import sys
+
+is_python2 = sys.version_info[0] == 2
 
 ##############################################################################
 
@@ -1887,7 +1890,7 @@ def Readfile(file_path):
             Error("You must feed me with data on STDIN!")
     else:
         try:
-            with open(file_path) as f:
+            with io.open(file_path, encoding="utf-8") as f:
                 contents = f.read()
         except IOError as exception:
             Error("Cannot read file: {}\n{}".format(file_path, exception))
@@ -1898,9 +1901,12 @@ def Readfile(file_path):
 
 def Savefile(file_path, lines):
     try:
-        with open(file_path, "w") as f:
+        with io.open(file_path, "w", encoding="utf-8") as f:
             for line in lines:
-                f.write(line + "\n")
+                if is_python2:
+                    f.write((line + "\n").decode("utf-8"))
+                else:
+                    f.write(line + "\n")
     except IOError as exception:
         Error("Cannot open file for writing: {}\n{}".format(file_path, exception))
 
@@ -2047,7 +2053,7 @@ class CommandLine:
         ret = []
 
         # We need lists, not strings (such as from %!options)
-        if isinstance(cmdline, str):
+        if not isinstance(cmdline, list):
             cmdline = self._tokenize(cmdline)
 
         # Extract name/value pair of all configs, check for invalid names


### PR DESCRIPTION
Since e4e56d9 txt2tags dropped `--encoding` and is only supporting UTF-8
as the input and output file encoding. In this commit this is now
explicitly enforced in the reading/writing files routines.

Sometimes, depending on the OS and the environment settings, UTF-8 is
not the default encoding for `open()`. For example, in Windows it could be
cp1252. In that case, a valid UTF-8 input file is read as cp1252 when no
encoding is specified in `open()`. Learn more at
https://stackoverflow.com/a/42070962/.

Note that for Python 2, now all the file contents is available as a
Unicode string (`u"foo"` instead of `"foo" `). So explicit checks for
`isinstance(str)` will fail, as well as code that assumes `str`.

Fixes #212