### PR TITLE
[ attempt at #228 ] definition lists in markdown

### DIFF
--- a/samples/sample.md
+++ b/samples/sample.md
@@ -116,15 +116,22 @@ identifier (plus).
 The definition list identifier is a colon, followed by
 the term. The term contents is placed on the next line.
 
-: orange
-a yellow fruit
-: apple
-a green or red fruit
-: other fruits
-  * wee!
+orange
+
+:   a yellow fruit
+
+apple
+
+:   a green or red fruit
+
+other fruits
+
+:     * wee!
   * mixing lists
 1. again!
 1. and again!
+
+
 
 # Tables 
 

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1243,10 +1243,12 @@ def getTags(config):
             "listItemOpen": "*",
             "numlistItemLine": None,
             "numlistItemOpen": "1.",
-            "deflistItem1Open": ": ",
-            "deflistItem1Close": None,
-            "deflistItem2Open": None,
-            "deflistItem2Close": None,
+            "deflistItem1Open": None,
+            "deflistItem1Close": "\n\n",
+            "deflistItem2Open": ":   ",
+              # Following PanDoc, https://pandoc.org/MANUAL.html#definition-lists
+              # PanDoc in turn follows PHP Markdown Extra: https://michelf.ca/projects/php-markdown/extra/#def-list
+            "deflistItem2Close": "\n",
             # Verbatim block
             "blockVerbOpen": None,
             "blockVerbClose": None,


### PR DESCRIPTION
I tried to change the generated markdown for definition lists to match PHP Markdown Extra / PanDoc.

Currently, the -t md just reproduces the t2t format of definition lists, which is not matching any flavor of markdown, AFAICT.

What I am trying to produce is in the patch to sample.md.
(This does not handle nested lists correctly, but so doesn't the status quo either.)

However, I do not get there because the framework inserts a newline between the `deflistItem2Open` tag and the description text.

To fix this, the framework has to be changed, it is not sufficient to tinker with the values of deflistItem*, it seems.

Run test/run.py to see the difference between what my patch achieves and where we want to get to.