### PR TITLE
Fix #233. Print USAGE message instead of Exception traceback.

### DIFF
--- a/txt2tags.py
+++ b/txt2tags.py
@@ -5017,10 +5017,7 @@ def exec_command_line(user_cmdline=None):
     if len(infiles) == 1:
         infile = infiles[0]
     else:
-        Error(
-            "Pass exactly one input file (see --help). "
-            "Example: {} -t html file.t2t".format(my_name)
-        )
+        Quit(USAGE)
 
     config, doc = process_source_file(infile)
     headers, config_source, body = doc


### PR DESCRIPTION
Fixes issue #233.

Instead of throwing an Exception when no file is provided, issues the USAGE message.

