### PR TITLE
issue #227 md table: correct title cell separators

### DIFF
--- a/txt2tags.py
+++ b/txt2tags.py
@@ -1265,7 +1265,7 @@ def getTags(config):
             "imgAlignCenter": None,
             # Table attributes
             "tableTitleRowOpen": "| ",
-            "tableTitleRowClose": "|\n|---------------|",
+            "tableTitleRowClose": None,
             "tableTitleCellSep": " |",
             "tableRowOpen": "|",
             "tableRowClose": "|",
@@ -3393,6 +3393,11 @@ class TableMaster:
                     o, c = rowopen, rowclose
                 row = tagged_cells.pop(0)
                 tagged_rows.append(o + row + c)
+                if rowdata["title"] and TARGET == "md":
+                    titrowcloserow = "|"
+                    for cell in rowdata["cells"]:
+                        titrowcloserow += "---|"
+                    tagged_rows.append(titrowcloserow)
 
         # Join the pieces together
         fulltable = []


### PR DESCRIPTION
class TableMaster function dump has a hack for tex output as well, so I saw not much harm to add a hack for md table titles too. An md table row is marked as title row, by adding a row beneath it with as much '---' cells as there are cells in the title row.