### PR TITLE
Add viewport in generated HTML code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next (unreleased)
+
+* Add viewport in HTML output (@patrick-g).
+
 # 3.8 (2023-02-17)
 
 * Raise minimum supported Python version to 3.7 (Jendrik Seipp).

--- a/samples/sample.html
+++ b/samples/sample.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <title>TXT2TAGS SAMPLE</title>
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/headers/ok/1.html
+++ b/test/headers/ok/1.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/12.html
+++ b/test/headers/ok/12.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/123.html
+++ b/test/headers/ok/123.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/123b.html
+++ b/test/headers/ok/123b.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/123eb.html
+++ b/test/headers/ok/123eb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/123k.html
+++ b/test/headers/ok/123k.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/123kb.html
+++ b/test/headers/ok/123kb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/12cb.html
+++ b/test/headers/ok/12cb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/12e.html
+++ b/test/headers/ok/12e.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/12eb.html
+++ b/test/headers/ok/12eb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/1c3b.html
+++ b/test/headers/ok/1c3b.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/1ccb.html
+++ b/test/headers/ok/1ccb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/1e.html
+++ b/test/headers/ok/1e.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/1e3b.html
+++ b/test/headers/ok/1e3b.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/1ec.html
+++ b/test/headers/ok/1ec.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/1ee.html
+++ b/test/headers/ok/1ee.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/1eeb.html
+++ b/test/headers/ok/1eeb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/c.html
+++ b/test/headers/ok/c.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/c23b.html
+++ b/test/headers/ok/c23b.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/c2cb.html
+++ b/test/headers/ok/c2cb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/c2eb.html
+++ b/test/headers/ok/c2eb.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/cc3b.html
+++ b/test/headers/ok/cc3b.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/ce3b.html
+++ b/test/headers/ok/ce3b.html
@@ -5,6 +5,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/eb.html
+++ b/test/headers/ok/eb.html
@@ -4,6 +4,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/ecb.html
+++ b/test/headers/ok/ecb.html
@@ -4,6 +4,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/ek.html
+++ b/test/headers/ok/ek.html
@@ -4,6 +4,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/ekb.html
+++ b/test/headers/ok/ekb.html
@@ -4,6 +4,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/headers/ok/ekkkb.html
+++ b/test/headers/ok/ekkkb.html
@@ -4,6 +4,7 @@
 
 
 
+
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}
 blockquote:first-letter{margin: .2em .1em .1em 0; font-size: 160%; font-weight: bold;}

--- a/test/marks/ok/comment.html
+++ b/test/marks/ok/comment.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/deflist.html
+++ b/test/marks/ok/deflist.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/image.html
+++ b/test/marks/ok/image.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/inline.html
+++ b/test/marks/ok/inline.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/line.html
+++ b/test/marks/ok/line.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/link.html
+++ b/test/marks/ok/link.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/list.html
+++ b/test/marks/ok/list.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/numlist.html
+++ b/test/marks/ok/numlist.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/numtitle.html
+++ b/test/marks/ok/numtitle.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/paragraph.html
+++ b/test/marks/ok/paragraph.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/quote.html
+++ b/test/marks/ok/quote.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/raw.html
+++ b/test/marks/ok/raw.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/table.html
+++ b/test/marks/ok/table.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/tagged.html
+++ b/test/marks/ok/tagged.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/title.html
+++ b/test/marks/ok/title.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/marks/ok/verbatim.html
+++ b/test/marks/ok/verbatim.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/options/ok/headers-1.html
+++ b/test/options/ok/headers-1.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/options/ok/headers-2.html
+++ b/test/options/ok/headers-2.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/options/ok/no-style-1.html
+++ b/test/options/ok/no-style-1.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/options/ok/no-style-2.html
+++ b/test/options/ok/no-style-2.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;
   font-style: oblique; padding-left: 1em;}

--- a/test/options/ok/style-1.html
+++ b/test/options/ok/style-1.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" href="css">
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;

--- a/test/options/ok/style-2.html
+++ b/test/options/ok/style-2.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="generator" content="https://txt2tags.org">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" href="other.css">
 <link rel="stylesheet" href="css">
 <style>

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -226,6 +226,7 @@ HEADER_TEMPLATE = {
 <meta charset="%(ENCODING)s">
 <title>%(HEADER1)s</title>
 <meta name="generator" content="https://txt2tags.org">
+<meta name=viewport content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="%(STYLE)s">
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;

--- a/txt2tags.py
+++ b/txt2tags.py
@@ -226,7 +226,7 @@ HEADER_TEMPLATE = {
 <meta charset="%(ENCODING)s">
 <title>%(HEADER1)s</title>
 <meta name="generator" content="https://txt2tags.org">
-<meta name=viewport content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" href="%(STYLE)s">
 <style>
 blockquote{margin: 1em 2em; border-left: 2px solid #999;


### PR DESCRIPTION
To enable Responsive Design the <meta> viewport element was added to the HTML generated by txt2tags.

Fixes #249